### PR TITLE
Use an autoload to add pythontest-test-runner to safe local variables

### DIFF
--- a/pythontest.el
+++ b/pythontest.el
@@ -24,6 +24,8 @@
   :local t
   :group 'python)
 
+;;;###autoload (put 'pythontest-test-runner 'safe-local-variable 'stringp)
+
 (defcustom pythontest-unittest-command "python3 -m unittest"
   "Command to be executed when running unittest."
   :type 'string


### PR DESCRIPTION
This allows using it in dir and file locals without needing specific local configuration.

It is also possible to add a "better" predicate that checks that the setting is _correct_, but this is plenty enough for checking that the local configuration is _safe_.

I'll also note that I have done the FSF paperwork for Emacs, which may become relevant as I'd recommend suggesting to add this into the Python mode included in Emacs.

A similar extension was recently done for the Go mode, see https://git.savannah.gnu.org/cgit/emacs.git/commit/etc/NEWS?id=f249c81f868e8fea9d2a05ce258b3ebefba6620f